### PR TITLE
Add support for unicode values

### DIFF
--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -57,7 +57,10 @@ class MaltegoEntity(object):
 			
 	def returnEntity(self):
 		print "<Entity Type=\"" + str(self.entityType) + "\">";
-		print "<Value>" + str(self.value) + "</Value>";
+		try:
+			print "<Value>" + str(self.value) + "</Value>";
+		except UnicodeEncodeError:
+			print "<Value>" + unicode(self.value) + "</Value>";
 		print "<Weight>" + str(self.weight) + "</Weight>";
 		if (self.displayInformation is not None):
 			print "<DisplayInformation><Label Name=\"\" Type=\"text/html\"><![CDATA[" + str(self.displayInformation) + "]]></Label></DisplayInformation>";


### PR DESCRIPTION
I ran into an issue with transforms erroring out while returning Unicode values (say simplified Chinese). This updates that issue so it can return properly formatted Unicode.
