### PR TITLE
Add a function to return the results of a transform as a variable

### DIFF
--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -17,157 +17,157 @@
 import sys
 
 class MaltegoEntity(object):
-	value = "";
-	weight = 100;
-	displayInformation = None;
-	additionalFields = [];
-	iconURL = "";
+	value = ""
+	weight = 100
+	displayInformation = None
+	additionalFields = []
+	iconURL = ""
 	entityType = "Phrase"
 
 	def __init__(self,eT=None,v=None):
 		if (eT is not None):
-			self.entityType = eT;
+			self.entityType = eT
 		if (v is not None):
-			self.value = sanitise(v);
-		self.additionalFields = [];
-		self.displayInformation = None;
+			self.value = sanitise(v)
+		self.additionalFields = []
+		self.displayInformation = None
 
 	def setType(self,eT=None):
 		if (eT is not None):
-			self.entityType = eT;
+			self.entityType = eT
 
 	def setValue(self,eV=None):
 		if (eV is not None):
-			self.value = sanitise(eV);
+			self.value = sanitise(eV)
 
 	def setWeight(self,w=None):
 		if (w is not None):
-			self.weight = w;
+			self.weight = w
 
 	def setDisplayInformation(self,di=None):
 		if (di is not None):
 			self.displayInformation = di;		
 
 	def addAdditionalFields(self,fieldName=None,displayName=None,matchingRule=False,value=None):
-		self.additionalFields.append([sanitise(fieldName),sanitise(displayName),matchingRule,sanitise(value)]);
+		self.additionalFields.append([sanitise(fieldName),sanitise(displayName),matchingRule,sanitise(value)])
 
 	def setIconURL(self,iU=None):
 		if (iU is not None):
-			self.iconURL = iU;
+			self.iconURL = iU
 
 	def returnEntity(self):
-		print "<Entity Type=\"" + str(self.entityType) + "\">";
+		print "<Entity Type=\"" + str(self.entityType) + "\">"
 		try:
-			print "<Value>" + str(self.value) + "</Value>";
+			print "<Value>" + str(self.value) + "</Value>"
 		except UnicodeEncodeError:
-			print "<Value>" + unicode(self.value) + "</Value>";
-		print "<Weight>" + str(self.weight) + "</Weight>";
+			print "<Value>" + unicode(self.value) + "</Value>"
+		print "<Weight>" + str(self.weight) + "</Weight>"
 		if (self.displayInformation is not None):
-			print "<DisplayInformation><Label Name=\"\" Type=\"text/html\"><![CDATA[" + str(self.displayInformation) + "]]></Label></DisplayInformation>";
+			print "<DisplayInformation><Label Name=\"\" Type=\"text/html\"><![CDATA[" + str(self.displayInformation) + "]]></Label></DisplayInformation>"
 		if (len(self.additionalFields) > 0):
-			print "<AdditionalFields>";
+			print "<AdditionalFields>"
 			for i in range(len(self.additionalFields)):
 				if (str(self.additionalFields[i][2]) <> "strict"):
-					print "<Field Name=\"" + str(self.additionalFields[i][0]) + "\" DisplayName=\"" + str(self.additionalFields[i][1]) + "\">" + str(self.additionalFields[i][3]) + "</Field>";
+					print "<Field Name=\"" + str(self.additionalFields[i][0]) + "\" DisplayName=\"" + str(self.additionalFields[i][1]) + "\">" + str(self.additionalFields[i][3]) + "</Field>"
 				else:
-					print "<Field MatchingRule=\"" + str(self.additionalFields[i][2]) + "\" Name=\"" + str(self.additionalFields[i][0]) + "\" DisplayName=\"" + str(self.additionalFields[i][1]) + "\">" + str(self.additionalFields[i][3]) + "</Field>";
-			print "</AdditionalFields>";
+					print "<Field MatchingRule=\"" + str(self.additionalFields[i][2]) + "\" Name=\"" + str(self.additionalFields[i][0]) + "\" DisplayName=\"" + str(self.additionalFields[i][1]) + "\">" + str(self.additionalFields[i][3]) + "</Field>"
+			print "</AdditionalFields>"
 		if (len(self.iconURL) > 0):
-			print "<IconURL>" + self.iconURL + "</IconURL>";
-		print "</Entity>";
+			print "<IconURL>" + self.iconURL + "</IconURL>"
+		print "</Entity>"
 
 class MaltegoTransform(object):
 	entities = []
 	exceptions = []
 	UIMessages = []
-	values = {};
+	values = {}
 
 	def __init__(self):
-		values = {};
-		value = None;
+		values = {}
+		value = None
 
 	def parseArguments(self,argv):
 		if (argv[1] is not None):
-			self.value = argv[1];
+			self.value = argv[1]
 
 		if (len(argv) > 2):
 			if (argv[2] is not None):
-				vars = argv[2].split('#');
+				vars = argv[2].split('#')
 				for x in range(0,len(vars)):
 					vars_values = vars[x].split('=')
 					if (len(vars_values) == 2):
-						self.values[vars_values[0]] = vars_values[1];
+						self.values[vars_values[0]] = vars_values[1]
 
 	def getValue(self):
 		if (self.value is not None):
-			return self.value;
+			return self.value
 
 	def getVar(self,varName):
 		if (varName in self.values.keys()):
 			if (self.values[varName] is not None):
-				return self.values[varName];
+				return self.values[varName]
 
 	def addEntity(self,enType,enValue):
-		me = MaltegoEntity(enType,enValue);
-		self.addEntityToMessage(me);
-		return self.entities[len(self.entities)-1];
+		me = MaltegoEntity(enType,enValue)
+		self.addEntityToMessage(me)
+		return self.entities[len(self.entities)-1]
 
 	def addEntityToMessage(self,maltegoEntity):
-		self.entities.append(maltegoEntity);
+		self.entities.append(maltegoEntity)
 
 	def addUIMessage(self,message,messageType="Inform"):
-		self.UIMessages.append([messageType,message]);
+		self.UIMessages.append([messageType,message])
 
 	def addException(self,exceptionString):
-		self.exceptions.append(exceptionString);
+		self.exceptions.append(exceptionString)
 
 	def throwExceptions(self):
-		print "<MaltegoMessage>";
-		print "<MaltegoTransformExceptionMessage>";
+		print "<MaltegoMessage>"
+		print "<MaltegoTransformExceptionMessage>"
 		print "<Exceptions>"
 
 		for i in range(len(self.exceptions)):
-			print "<Exception>" + self.exceptions[i] + "</Exception>";
+			print "<Exception>" + self.exceptions[i] + "</Exception>"
 		print "</Exceptions>"	
-		print "</MaltegoTransformExceptionMessage>";
-		print "</MaltegoMessage>";
-		exit();
+		print "</MaltegoTransformExceptionMessage>"
+		print "</MaltegoMessage>"
+		exit()
 
 	def returnOutput(self):
-		print "<MaltegoMessage>";
-		print "<MaltegoTransformResponseMessage>";
+		print "<MaltegoMessage>"
+		print "<MaltegoTransformResponseMessage>"
 
 		print "<Entities>"
 		for i in range(len(self.entities)):
-			self.entities[i].returnEntity();
+			self.entities[i].returnEntity()
 		print "</Entities>"
 
 		print "<UIMessages>"
 		for i in range(len(self.UIMessages)):
-			print "<UIMessage MessageType=\"" + self.UIMessages[i][0] + "\">" + self.UIMessages[i][1] + "</UIMessage>";
+			print "<UIMessage MessageType=\"" + self.UIMessages[i][0] + "\">" + self.UIMessages[i][1] + "</UIMessage>"
 		print "</UIMessages>"
 
-		print "</MaltegoTransformResponseMessage>";
-		print "</MaltegoMessage>";
+		print "</MaltegoTransformResponseMessage>"
+		print "</MaltegoMessage>"
 
 	def writeSTDERR(self,msg):
-		sys.stderr.write(str(msg));
+		sys.stderr.write(str(msg))
 
 	def heartbeat(self):
-		self.writeSTDERR("+");
+		self.writeSTDERR("+")
 
 	def progress(self,percent):
-		self.writeSTDERR("%" + str(percent));
+		self.writeSTDERR("%" + str(percent))
 
 	def debug(self,msg):
-		self.writeSTDERR("D:" + str(msg));
+		self.writeSTDERR("D:" + str(msg))
 
 
 
 def sanitise(value):
-	replace_these = ["&",">","<"];
-	replace_with = ["&amp;","&gt;","&lt;"];
-	tempvalue = value;
+	replace_these = ["&",">","<"]
+	replace_with = ["&amp;","&gt;","&lt;"]
+	tempvalue = value
 	for i in range(0,len(replace_these)):
-		tempvalue = tempvalue.replace(replace_these[i],replace_with[i]);
-	return tempvalue;
+		tempvalue = tempvalue.replace(replace_these[i],replace_with[i])
+	return tempvalue

--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -159,6 +159,9 @@ class MaltegoTransform(object):
 		print "</MaltegoMessage>"
 		exit()
 
+	def getOutput(self):
+		return map(lambda x: x.getProps(), self.entities)
+
 	def returnOutput(self):
 		print "<MaltegoMessage>"
 		print "<MaltegoTransformResponseMessage>"

--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -57,7 +57,10 @@ class MaltegoEntity(object):
 			
 	def returnEntity(self):
 		print "<Entity Type=\"" + str(self.entityType) + "\">";
-		print "<Value>" + str(self.value) + "</Value>";
+		try:
+			print "<Value>" + str(self.value) + "</Value>";
+		except UnicodeEncodeError:
+			print "<Value>" + unicode(self.value) + "</Value>";
 		print "<Weight>" + str(self.weight) + "</Weight>";
 		if (self.displayInformation is not None):
 			print "<DisplayInformation><Label Name=\"\" Type=\"text/html\"><![CDATA[" + str(self.displayInformation) + "]]></Label></DisplayInformation>";

--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -52,8 +52,34 @@ class MaltegoEntity(object):
 		self.additionalFields.append([sanitise(fieldName),sanitise(displayName),matchingRule,sanitise(value)])
 
 	def setIconURL(self,iU=None):
-		if (iU is not None):
 			self.iconURL = iU
+
+	def getType(self):
+		return self.entityType
+
+	def getValue(self):
+		return self.value
+
+	def getWeight(self):
+		return self.weight
+
+	def getDisplayInformation(self):
+		return self.displayInformation
+
+	def getAdditionalFields(self):
+		return self.additionalFields
+
+	def getIconURL(self):
+		return self.iconURL
+
+	def getProps(self):
+		return {'type': self.getType(),
+			'value': self.getValue(),
+			'weight': self.getWeight(),
+			'displayInforation': self.getDisplayInformation(),
+			'additionalFields': self.getAdditionalFields(),
+			'iconURL': self.getIconURL(),
+			}
 
 	def returnEntity(self):
 		print "<Entity Type=\"" + str(self.entityType) + "\">"

--- a/MaltegoTransform.py
+++ b/MaltegoTransform.py
@@ -23,7 +23,7 @@ class MaltegoEntity(object):
 	additionalFields = [];
 	iconURL = "";
 	entityType = "Phrase"
-	
+
 	def __init__(self,eT=None,v=None):
 		if (eT is not None):
 			self.entityType = eT;
@@ -31,30 +31,30 @@ class MaltegoEntity(object):
 			self.value = sanitise(v);
 		self.additionalFields = [];
 		self.displayInformation = None;
-		
+
 	def setType(self,eT=None):
 		if (eT is not None):
 			self.entityType = eT;
-	
+
 	def setValue(self,eV=None):
 		if (eV is not None):
 			self.value = sanitise(eV);
-		
+
 	def setWeight(self,w=None):
 		if (w is not None):
 			self.weight = w;
-	
+
 	def setDisplayInformation(self,di=None):
 		if (di is not None):
 			self.displayInformation = di;		
-			
+
 	def addAdditionalFields(self,fieldName=None,displayName=None,matchingRule=False,value=None):
 		self.additionalFields.append([sanitise(fieldName),sanitise(displayName),matchingRule,sanitise(value)]);
-	
+
 	def setIconURL(self,iU=None):
 		if (iU is not None):
 			self.iconURL = iU;
-			
+
 	def returnEntity(self):
 		print "<Entity Type=\"" + str(self.entityType) + "\">";
 		try:
@@ -75,21 +75,21 @@ class MaltegoEntity(object):
 		if (len(self.iconURL) > 0):
 			print "<IconURL>" + self.iconURL + "</IconURL>";
 		print "</Entity>";
-	
+
 class MaltegoTransform(object):
 	entities = []
 	exceptions = []
 	UIMessages = []
 	values = {};
-	
+
 	def __init__(self):
 		values = {};
 		value = None;
-	
+
 	def parseArguments(self,argv):
 		if (argv[1] is not None):
 			self.value = argv[1];
-			
+
 		if (len(argv) > 2):
 			if (argv[2] is not None):
 				vars = argv[2].split('#');
@@ -97,71 +97,71 @@ class MaltegoTransform(object):
 					vars_values = vars[x].split('=')
 					if (len(vars_values) == 2):
 						self.values[vars_values[0]] = vars_values[1];
-	
+
 	def getValue(self):
 		if (self.value is not None):
 			return self.value;
-	
+
 	def getVar(self,varName):
 		if (varName in self.values.keys()):
 			if (self.values[varName] is not None):
 				return self.values[varName];
-	
+
 	def addEntity(self,enType,enValue):
 		me = MaltegoEntity(enType,enValue);
 		self.addEntityToMessage(me);
 		return self.entities[len(self.entities)-1];
-	
+
 	def addEntityToMessage(self,maltegoEntity):
 		self.entities.append(maltegoEntity);
-		
+
 	def addUIMessage(self,message,messageType="Inform"):
 		self.UIMessages.append([messageType,message]);
-	
+
 	def addException(self,exceptionString):
 		self.exceptions.append(exceptionString);
-		
+
 	def throwExceptions(self):
 		print "<MaltegoMessage>";
 		print "<MaltegoTransformExceptionMessage>";
 		print "<Exceptions>"
-		
+
 		for i in range(len(self.exceptions)):
 			print "<Exception>" + self.exceptions[i] + "</Exception>";
 		print "</Exceptions>"	
 		print "</MaltegoTransformExceptionMessage>";
 		print "</MaltegoMessage>";
 		exit();
-		
+
 	def returnOutput(self):
 		print "<MaltegoMessage>";
 		print "<MaltegoTransformResponseMessage>";
-						
+
 		print "<Entities>"
 		for i in range(len(self.entities)):
 			self.entities[i].returnEntity();
 		print "</Entities>"
-						
+
 		print "<UIMessages>"
 		for i in range(len(self.UIMessages)):
 			print "<UIMessage MessageType=\"" + self.UIMessages[i][0] + "\">" + self.UIMessages[i][1] + "</UIMessage>";
 		print "</UIMessages>"
-			
+
 		print "</MaltegoTransformResponseMessage>";
 		print "</MaltegoMessage>";
-		
+
 	def writeSTDERR(self,msg):
 		sys.stderr.write(str(msg));
-	
+
 	def heartbeat(self):
 		self.writeSTDERR("+");
-	
+
 	def progress(self,percent):
 		self.writeSTDERR("%" + str(percent));
-	
+
 	def debug(self,msg):
 		self.writeSTDERR("D:" + str(msg));
-			
+
 
 
 def sanitise(value):


### PR DESCRIPTION
The returnOutput() function is badly named, since it actually prints the transform results to stdio rather than returning the results to the caller. To preserve API compatibility a new function is introduced which returns a list of dicts of entities for further processing.

This also facilitates the creation to scripts which can either be run as command-line tools or as local transforms depending on switches or environment.